### PR TITLE
fix: GPIO permission moved to the lib

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,8 +17,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.marcpoppleton.wsepd">
 
-    <uses-permission android:name="com.google.android.things.permission.USE_PERIPHERAL_IO" />
-
     <application
         android:allowBackup="true"
         android:icon="@android:drawable/sym_def_app_icon"

--- a/app/src/main/java/com/marcpoppleton/wsepd/MainActivity.kt
+++ b/app/src/main/java/com/marcpoppleton/wsepd/MainActivity.kt
@@ -23,6 +23,7 @@ import com.marcpoppleton.wsepdkdriver.Epd7in5v2
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.w3c.dom.Text
 import java.io.IOException
 
 
@@ -34,17 +35,15 @@ class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_dashboard)
         display = Epd7in5v2(layoutInflater, R.layout.activity_dashboard)
     }
 
     override fun onResume() {
         super.onResume()
 
+        val title = display.findViewById<TextView>(R.id.title) as TextView
         GlobalScope.launch {
             for(i in 0..10){
-                Log.d(TAG,"loop number $i")
-                val title = display.findViewById<TextView>(R.id.title) as TextView
                 title.text = getString(R.string.refresh_title,i)
                 display.refresh()
                 delay(45000)
@@ -53,17 +52,8 @@ class MainActivity : Activity() {
     }
 
     override fun onDestroy() {
+        display.close()
         super.onDestroy()
-        Log.d(TAG, "onDestroy called, closing display")
-        try {
-            display.close()
-        } catch (e: IOException) {
-            Log.e(
-                TAG,
-                "Error closing display",
-                e
-            )
-        }
     }
 
 }

--- a/wsepdkdriver/src/main/AndroidManifest.xml
+++ b/wsepdkdriver/src/main/AndroidManifest.xml
@@ -14,4 +14,6 @@
     limitations under the License.
     -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.marcpoppleton.wsepdkdriver" />
+    package="com.marcpoppleton.wsepdkdriver">
+    <uses-permission android:name="com.google.android.things.permission.USE_PERIPHERAL_IO" />
+</manifest>


### PR DESCRIPTION
To access the GPIO the app needs specific permission. If the permission is missing from the apps Manifest file no warning will be shown to the dev and the app will crash at runtime. To avoid this the permission is embedded in the lib's Manifest and will be merged in the final manifest file at build time.
Closes #1