### PR TITLE
fix: Device orientation can be set by user of the lib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ implementation 'com.marcpoppleton:wsepdkdriver:1.0.1'
 ```
 
 In your application's code you can use a e-Paper device like a display.
-In the following example you can see how a 7,5" Waveshare device is used to display a dashboard updated every 45 seconds.
+In the following example you can see how a 7,5" Waveshare device is used to display a layout in which we update the content of a TextView.
 
 ```kotlin
 class MainActivity : Activity() {
@@ -36,7 +36,7 @@ class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        display = Epd7in5v2(layoutInflater, R.layout.activity_dashboard)
+        display = Epd7in5v2(layoutInflater, R.layout.epd_hello)
     }
 
     override fun onResume() {
@@ -44,10 +44,8 @@ class MainActivity : Activity() {
 
         val title = display.findViewById<TextView>(R.id.title) as TextView
         GlobalScope.launch {
-            for(i in 0..10){
-                title.text = getString(R.string.refresh_title,i)
+                title.text = getString(R.string.hello_world)
                 display.refresh()
-                delay(45000)
             }
         }
     }
@@ -56,11 +54,33 @@ class MainActivity : Activity() {
         display.close()
         super.onDestroy()
     }
-
 }
 ```
 
 Calls to the ```refresh``` function must be done from a coroutine since all functions, except ```close```, are suspendable functions.
+
+Orientation
+--------
+
+By default the display renders the layout in landscape mode, the serial port on the bottom. Orientation can either be set when creating a Epd device or at any moment in your code.
+
+In the following example the orientation is set to ```PORTRAIT_RIGHT``` when the Epd device is created:
+```kotlin
+display = Epd7in5v2(layoutInflater, R.layout.activity_dashboard,Orientation.PORTRAIT_RIGHT)
+```
+
+On the other hand, in the next example the orientation is set at some moment of the code:
+```kotlin
+display.orientation = Orientation.LANDSCAPE_TOP
+display.refresh()
+```
+
+The possible values are:
+
+* ```Orientation.LANDSCAPE_BOTTOM```(the default orientation, with the serial port on the bottom)
+* ```Orientation.PORTRAIT_RIGHT```(portrait mode, with the serial port on the right)
+* ```Orientation.PORTRAIT_LEFT```(portrait mode, with the serial port on the left)
+* ```Orientation.PORTRAIT_TOP```(landscape mode, with the serial port on the top)
 
 
 License

--- a/app/src/main/java/com/marcpoppleton/wsepd/MainActivity.kt
+++ b/app/src/main/java/com/marcpoppleton/wsepd/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.TextView
 import com.marcpoppleton.wsepdkdriver.Epd7in5v2
+import com.marcpoppleton.wsepdkdriver.Orientation
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -35,25 +36,32 @@ class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        display = Epd7in5v2(layoutInflater, R.layout.activity_dashboard)
+        display = Epd7in5v2(layoutInflater, R.layout.activity_dashboard,Orientation.PORTRAIT_RIGHT)
     }
 
     override fun onResume() {
         super.onResume()
 
         val title = display.findViewById<TextView>(R.id.title) as TextView
+        val orientations = Orientation.values()
         GlobalScope.launch {
+            display.clear()
             for(i in 0..10){
                 title.text = getString(R.string.refresh_title,i)
+                display.orientation = orientations[i%4]
+                Log.d(TAG,"orientation is ${orientations[i%4]}")
                 display.refresh()
-                delay(45000)
+                delay(10000)
             }
         }
     }
 
     override fun onDestroy() {
-        display.close()
-        super.onDestroy()
+        GlobalScope.launch {
+            display.clear()
+            display.close()
+            super.onDestroy()
+        }
     }
 
 }

--- a/wsepdkdriver/src/main/java/com/marcpoppleton/wsepdkdriver/Epd7in5v2.kt
+++ b/wsepdkdriver/src/main/java/com/marcpoppleton/wsepdkdriver/Epd7in5v2.kt
@@ -18,6 +18,7 @@ package com.marcpoppleton.wsepdkdriver
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -27,7 +28,7 @@ import kotlin.experimental.or
 
 // For detailed specification refer to document https://www.waveshare.com/w/upload/6/60/7.5inch_e-Paper_V2_Specification.pdf
 
-class Epd7in5v2(private val layoutInflater: LayoutInflater,private val layoutReference: Int) : WsEpd() {
+class Epd7in5v2(private val layoutInflater: LayoutInflater,private val layoutReference: Int,var orientation: Orientation = Orientation.LANDSCAPE_BOTTOM) : WsEpd() {
 
     private val WIDTH = 800
     private val HEIGHT = 480
@@ -219,10 +220,18 @@ class Epd7in5v2(private val layoutInflater: LayoutInflater,private val layoutRef
 
     private fun loadBitmapFromView(): Bitmap? {
 
+        var width=WIDTH
+        var height=HEIGHT
+
+        if((orientation==Orientation.PORTRAIT_LEFT) || (orientation==Orientation.PORTRAIT_RIGHT) ){
+            width = HEIGHT
+            height = WIDTH
+        }
+
         val viewGroup = layout.rootView as ViewGroup
         viewGroup.measure(
-            View.MeasureSpec.makeMeasureSpec(WIDTH,View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(HEIGHT,View.MeasureSpec.EXACTLY)
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
         )
         viewGroup.layout(0, 0, viewGroup.measuredWidth, viewGroup.measuredHeight)
 
@@ -236,6 +245,17 @@ class Epd7in5v2(private val layoutInflater: LayoutInflater,private val layoutRef
         viewGroup.layout(viewGroup.left, viewGroup.top, viewGroup.right, viewGroup.bottom)
         viewGroup.draw(c)
 
-        return b
+        return when(orientation){
+            Orientation.PORTRAIT_RIGHT -> b.rotate(90f)
+            Orientation.PORTRAIT_LEFT -> b.rotate(-90f)
+            Orientation.LANDSCAPE_TOP -> b.rotate(180f)
+            Orientation.LANDSCAPE_BOTTOM -> b
+        }
+    }
+
+    fun Bitmap.rotate(angle: Float): Bitmap {
+        val matrix = Matrix()
+        matrix.postRotate(angle)
+        return Bitmap.createBitmap(this, 0, 0, this.width, this.height, matrix, true)
     }
 }

--- a/wsepdkdriver/src/main/java/com/marcpoppleton/wsepdkdriver/WsEpd.kt
+++ b/wsepdkdriver/src/main/java/com/marcpoppleton/wsepdkdriver/WsEpd.kt
@@ -24,6 +24,13 @@ import com.google.android.things.pio.SpiDevice
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 
+enum class Orientation {
+    LANDSCAPE_BOTTOM, //0° rotation
+    LANDSCAPE_TOP, //180° rotation
+    PORTRAIT_RIGHT, //90° rotation
+    PORTRAIT_LEFT, //-90° rotation
+}
+
 open class WsEpd() {
 
     private val SPI_NAME = "SPI0.0"


### PR DESCRIPTION
The orientation of the EPD device can be set either when calling the constructor or by setting the orientation property of the object. Four orientations are available, letting the user choose where the serial socket should sit relative to the layout. By default the orientation is landscape with the socket at the bottom. Closes #3